### PR TITLE
Update fee multiplier and byte fees

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -95,8 +95,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("canvas"),
 	impl_name: create_runtime_str!("canvas"),
 	authoring_version: 1,
-	spec_version: 7,
-	impl_version: 6,
+	spec_version: 8,
+	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };


### PR DESCRIPTION
The current dummy value for `FeeMultiplierUpdate` will keep the weight fee at `0` all the time. This allows spamming the canvas test net with long running contracts without any cost and in turn make the users unhappy. This sets it to what is used for polkadot and kusama. Please note that as for these chains the multiplier will be at its minimum most of the time because of the low utilization.

Additionally, the byte fee is now set so that 1CAN = 1Megabyte.