### PR TITLE
Add contracts-unstable-interface feature

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -49,7 +49,11 @@ pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substr
 substrate-wasm-builder =  { git = "https://github.com/paritytech/substrate", package = "substrate-wasm-builder" }
 
 [features]
-default = ["std"]
+default = [
+    "std",
+    # temporarily enable unstable contracts features by default, remove this before using on a production chain.
+    "contracts-unstable-interface",
+]
 std = [
     "codec/std",
     "frame-executive/std",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -80,3 +80,8 @@ std = [
     "pallet-contracts-primitives/std",
     "pallet-contracts-rpc-runtime-api/std",
 ]
+# Make contract callable functions marked as __unstable__ available. Do not enable
+# on live chains as those are subject to change.
+contracts-unstable-interface = [
+    "pallet-contracts/unstable-interface"
+]


### PR DESCRIPTION
Enable functions marked as `__unstable`, e.g. `seal_debug_message` and `seal_rent_status`.