### PR TITLE
Change pipeline to use Vault secrets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,10 +115,14 @@ publish:
       artifacts: true
     - job: build-mac
       artifacts: true
+  variables:
+    VAULT_SERVER_URL:              "https://vault.parity-mgmt-vault.parity.io"
+    VAULT_AUTH_PATH:               "gitlab-parity-io-jwt"
+    VAULT_AUTH_ROLE:               "cicd_gitlab_parity_${CI_PROJECT_NAME}"
   secrets:
     GITHUB_TOKEN:
-      vault:                    cicd/gitlab/$CI_PROJECT_PATH/GITHUB_TOKEN@kv
-      file:                     false
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/GITHUB_TOKEN@kv
+      file:                        false
   script:
     - git describe --tags
     - TAG_NAME=`git describe --tags`

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,6 +115,10 @@ publish:
       artifacts: true
     - job: build-mac
       artifacts: true
+  secrets:
+    GITHUB_TOKEN:
+      vault:                    cicd/gitlab/$CI_PROJECT_PATH/GITHUB_TOKEN@kv
+      file:                     false
   script:
     - git describe --tags
     - TAG_NAME=`git describe --tags`


### PR DESCRIPTION
Change behavior of the pipeline to use Vault secrets instead of project variables.
This PR can be merged after [MR](https://gitlab.parity.io/parity/infrastructure/cloud-infra/-/merge_requests/543) will get merged.