### PR TITLE
Synchronize with Substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,56 +38,37 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.3.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
  "generic-array 0.14.4",
 ]
 
 [[package]]
 name = "aes"
-version = "0.5.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "aes-soft",
- "aesni",
- "block-cipher",
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.7.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0301c9e9c443494d970a07885e8cf3e587bae8356a1d5abd0999068413f7205f"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
  "aes",
- "block-cipher",
+ "cipher",
+ "ctr",
  "ghash",
- "subtle 2.4.1",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
-dependencies = [
- "block-cipher",
- "byteorder",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aesni"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
-dependencies = [
- "block-cipher",
- "opaque-debug 0.3.0",
+ "subtle",
 ]
 
 [[package]]
@@ -295,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f06685bad74e0570f5213741bea82158279a4103d988e57bfada11ad230341"
+checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
 dependencies = [
  "async-attributes",
  "async-channel",
@@ -359,7 +340,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -372,7 +353,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -422,7 +403,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.26.0",
+ "object 0.26.2",
  "rustc-demangle",
 ]
 
@@ -479,11 +460,11 @@ source = "git+https://github.com/paritytech/grandpa-bridge-gadget?branch=hc-cont
 dependencies = [
  "beefy-primitives",
  "fnv",
- "futures 0.3.16",
+ "futures 0.3.17",
  "hex",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "sc-client-api",
  "sc-keystore",
  "sc-network",
@@ -509,7 +490,7 @@ source = "git+https://github.com/paritytech/grandpa-bridge-gadget?branch=hc-cont
 dependencies = [
  "beefy-gadget",
  "beefy-primitives",
- "futures 0.3.16",
+ "futures 0.3.17",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -601,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
+checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
 dependencies = [
  "crypto-mac 0.8.0",
  "digest 0.9.0",
@@ -676,15 +657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding 0.2.1",
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "block-cipher"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
-dependencies = [
  "generic-array 0.14.4",
 ]
 
@@ -784,9 +756,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cache-padded"
@@ -944,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 dependencies = [
  "jobserver",
 ]
@@ -980,24 +952,26 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chacha20"
-version = "0.5.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244fbce0d47e97e8ef2f63b81d5e05882cb518c68531eb33194990d7b7e85845"
+checksum = "f08493fa7707effc63254c66c6ea908675912493cd67952eda23c09fae2610b1"
 dependencies = [
- "stream-cipher",
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf18d374d66df0c05cdddd528a7db98f78c28e2519b120855c4f84c5027b1f5"
+checksum = "b6547abe025f4027edacd9edaa357aded014eecec42a5070d9b885c3c334aba2"
 dependencies = [
  "aead",
  "chacha20",
+ "cipher",
  "poly1305",
- "stream-cipher",
  "zeroize",
 ]
 
@@ -1021,33 +995,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff0e3bc0b6446b3f9663c1a6aba6ef06c5aeaa1bc92bd18077be337198ab9768"
 dependencies = [
  "multibase",
- "multihash",
+ "multihash 0.13.2",
  "unsigned-varint 0.5.1",
 ]
 
 [[package]]
 name = "cipher"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array 0.14.4",
 ]
 
 [[package]]
 name = "ckb-merkle-mountain-range"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e486fe53bb9f2ca0f58cb60e8679a5354fd6687a839942ef0a75967250289ca6"
+checksum = "4f061f97d64fd1822664bdfb722f7ae5469a97b77567390f7442be5b5dc82a5b"
 dependencies = [
  "cfg-if 0.1.10",
 ]
 
 [[package]]
 name = "clang-sys"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
+checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
 dependencies = [
  "glob",
  "libc",
@@ -1142,18 +1116,12 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cranelift-bforest"
@@ -1241,7 +1209,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "itertools 0.10.1",
+ "itertools",
  "log",
  "serde",
  "smallvec 1.6.1",
@@ -1358,22 +1326,22 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.1",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1387,12 +1355,21 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1424,7 +1401,7 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-primitives-core",
- "futures 0.3.16",
+ "futures 0.3.17",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "polkadot-node-primitives",
@@ -1448,7 +1425,7 @@ dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
  "cumulus-primitives-core",
- "futures 0.3.16",
+ "futures 0.3.17",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "polkadot-client",
@@ -1478,7 +1455,7 @@ source = "git+https://github.com/paritytech/cumulus?branch=hc-contract-experimen
 dependencies = [
  "async-trait",
  "dyn-clone",
- "futures 0.3.16",
+ "futures 0.3.17",
  "parity-scale-codec",
  "polkadot-primitives",
  "polkadot-runtime",
@@ -1502,7 +1479,7 @@ version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=hc-contract-experiment-patched-v0.9.9#3018a6c503c4aa832e7778177498f95e5e083633"
 dependencies = [
  "derive_more",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -1526,7 +1503,7 @@ version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=hc-contract-experiment-patched-v0.9.9#3018a6c503c4aa832e7778177498f95e5e083633"
 dependencies = [
  "cumulus-primitives-core",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -1772,7 +1749,7 @@ dependencies = [
  "byteorder",
  "digest 0.8.1",
  "rand_core 0.5.1",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -1785,7 +1762,7 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -1960,7 +1937,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.6",
  "zeroize",
 ]
 
@@ -2114,7 +2091,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
 ]
 
 [[package]]
@@ -2181,18 +2158,18 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c832d0ed507622c7cb98e9b7f10426850fc9d38527ab8071778dcc3a81d45875"
+checksum = "e8ac3ff5224ef91f3c97e03eb1de2db82743427e91aaa5ac635f454f0b164f5a"
 dependencies = [
  "either",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "log",
  "num-traits",
  "parity-scale-codec",
- "parking_lot 0.11.1",
- "scale-info",
+ "parking_lot 0.11.2",
+ "scale-info 1.0.0",
 ]
 
 [[package]]
@@ -2215,9 +2192,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+checksum = "80edafed416a46fb378521624fab1cfa2eb514784fd8921adbe8a8d8321da811"
 dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
@@ -2235,7 +2212,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2253,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2272,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "Inflector",
  "chrono",
@@ -2298,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2311,7 +2288,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2326,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "14.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -2337,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2363,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -2375,7 +2352,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.0.0",
@@ -2387,7 +2364,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2397,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -2414,7 +2391,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2428,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2437,7 +2414,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2510,9 +2487,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2525,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2535,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-cpupool"
@@ -2551,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
+checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2563,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
 name = "futures-lite"
@@ -2584,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -2608,15 +2585,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-timer"
@@ -2632,9 +2609,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
  "futures 0.1.31",
@@ -2701,9 +2678,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.3.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug 0.3.0",
  "polyval",
@@ -2872,16 +2849,6 @@ checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
-]
-
-[[package]]
-name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
@@ -2891,14 +2858,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac-drbg"
-version = "0.2.0"
+name = "hmac"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
- "hmac 0.7.1",
+ "crypto-mac 0.11.1",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -2929,7 +2906,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fnv",
  "itoa",
 ]
@@ -2962,16 +2939,16 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "http 0.2.4",
  "pin-project-lite 0.2.7",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
@@ -3056,11 +3033,11 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.11"
+version = "0.14.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
+checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -3070,7 +3047,7 @@ dependencies = [
  "httpdate 1.0.1",
  "itoa",
  "pin-project-lite 0.2.7",
- "tokio 1.10.0",
+ "tokio 1.11.0",
  "tower-service",
  "tracing",
  "want 0.3.0",
@@ -3118,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
+checksum = "c9a83ec4af652890ac713ffd8dc859e650420a5ef47f7b9be29b6664ab50fbc8"
 dependencies = [
  "if-addrs-sys",
  "libc",
@@ -3144,7 +3121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8ab7f67bad3240049cb24fb9cb0b4c2c6af4c245840917fbbdededeee91179"
 dependencies = [
  "async-io",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-lite",
  "if-addrs",
  "ipnet",
@@ -3232,7 +3209,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa110ec7b8f493f416eed552740d10e7030ad5f63b2308f82c9608ec2df275"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 2.0.2",
 ]
 
@@ -3271,15 +3248,6 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
@@ -3289,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jobserver"
@@ -3304,9 +3272,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.52"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
+checksum = "1866b355d9c878e5e607473cbe3f63282c0b7aad2db1dbebf55076c686918254"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3457,7 +3425,7 @@ dependencies = [
  "beef",
  "futures-channel",
  "futures-util",
- "hyper 0.14.11",
+ "hyper 0.14.12",
  "log",
  "serde",
  "serde_json",
@@ -3473,7 +3441,7 @@ checksum = "8e2834b6e7f57ce9a4412ed4d6dc95125d2c8612e68f86b9d9a07369164e4198"
 dependencies = [
  "async-trait",
  "fnv",
- "futures 0.3.16",
+ "futures 0.3.17",
  "jsonrpsee-types",
  "log",
  "pin-project 1.0.8",
@@ -3532,7 +3500,7 @@ checksum = "c3b6b85fc643f5acd0bffb2cc8a6d150209379267af0d41db72170021841f9f5"
 dependencies = [
  "kvdb",
  "parity-util-mem",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -3547,7 +3515,7 @@ dependencies = [
  "num_cpus",
  "owning_ref",
  "parity-util-mem",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "regex",
  "rocksdb",
  "smallvec 1.6.1",
@@ -3567,9 +3535,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.99"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libloading"
@@ -3599,13 +3567,13 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.37.1"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08053fbef67cd777049ef7a95ebaca2ece370b4ed7712c3fa404d69a88cb741b"
+checksum = "9004c06878ef8f3b4b4067e69a140d87ed20bf777287f82223e49713b36ee433"
 dependencies = [
  "atomic",
- "bytes 1.0.1",
- "futures 0.3.16",
+ "bytes 1.1.0",
+ "futures 0.3.17",
  "lazy_static",
  "libp2p-core",
  "libp2p-deflate",
@@ -3629,8 +3597,8 @@ dependencies = [
  "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
- "parity-multiaddr",
- "parking_lot 0.11.1",
+ "multiaddr",
+ "parking_lot 0.11.2",
  "pin-project 1.0.8",
  "smallvec 1.6.1",
  "wasm-timer",
@@ -3638,31 +3606,31 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554d3e7e9e65f939d66b75fd6a4c67f258fe250da61b91f46c545fc4a89b51d9"
+checksum = "af9b4abdeaa420593a297c8592f63fad4234f4b88dc9343b8fd8e736c35faa59"
 dependencies = [
  "asn1_der",
  "bs58",
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "lazy_static",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.5.0",
  "log",
- "multihash",
+ "multiaddr",
+ "multihash 0.14.0",
  "multistream-select",
- "parity-multiaddr",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "pin-project 1.0.8",
  "prost",
  "prost-build",
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.5",
+ "sha2 0.9.6",
  "smallvec 1.6.1",
  "thiserror",
  "unsigned-varint 0.7.0",
@@ -3672,23 +3640,23 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2181a641cd15f9b6ba71b1335800f309012a0a97a29ffaabbbf40e9d3d58f08"
+checksum = "66097fccc0b7f8579f90a03ea76ba6196332ea049fd07fd969490a06819dcdc8"
 dependencies = [
  "flate2",
- "futures 0.3.16",
+ "futures 0.3.17",
  "libp2p-core",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e63dab8b5ff35e0c101a3e51e843ba782c07bbb1682f5fd827622e0d02b98b"
+checksum = "58ff08b3196b85a17f202d80589e93b1660a574af67275706657fdc762e42c32"
 dependencies = [
  "async-std-resolver",
- "futures 0.3.16",
+ "futures 0.3.17",
  "libp2p-core",
  "log",
  "smallvec 1.6.1",
@@ -3697,13 +3665,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48a9b570f6766301d9c4aa00fce3554cad1598e2f466debbc4dde909028417cf"
+checksum = "404eca8720967179dac7a5b4275eb91f904a53859c69ca8d018560ad6beb214f"
 dependencies = [
  "cuckoofilter",
  "fnv",
- "futures 0.3.16",
+ "futures 0.3.17",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3715,16 +3683,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.30.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b0c8506a6ec3344b9e706d7c7a6dba826f8ede735cfe13dde12a8c263c4af9"
+checksum = "b1cc48709bcbc3a3321f08a73560b4bbb4166a7d56f6fdb615bc775f4f91058e"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "base64 0.13.0",
  "byteorder",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fnv",
- "futures 0.3.16",
+ "futures 0.3.17",
  "hex_fmt",
  "libp2p-core",
  "libp2p-swarm",
@@ -3733,7 +3701,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "regex",
- "sha2 0.9.5",
+ "sha2 0.9.6",
  "smallvec 1.6.1",
  "unsigned-varint 0.7.0",
  "wasm-timer",
@@ -3741,11 +3709,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f668f00efd9883e8b7bcc582eaf0164615792608f886f6577da18bcbeea0a46"
+checksum = "a7b61f6cf07664fb97016c318c4d4512b3dd4cc07238607f3f0163245f99008e"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3757,23 +3725,23 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07312ebe5ee4fd2404447a0609814574df55c65d4e20838b957bbd34907d820"
+checksum = "50ed78489c87924235665a0ab345b298ee34dff0f7ad62c0ba6608b2144fb75e"
 dependencies = [
  "arrayvec 0.5.2",
  "asynchronous-codec 0.6.0",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "either",
  "fnv",
- "futures 0.3.16",
+ "futures 0.3.17",
  "libp2p-core",
  "libp2p-swarm",
  "log",
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.5",
+ "sha2 0.9.6",
  "smallvec 1.6.1",
  "uint",
  "unsigned-varint 0.7.0",
@@ -3783,14 +3751,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.30.2"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efa70c1c3d2d91237f8546e27aeb85e287d62c066a7b4f3ea6a696d43ced714"
+checksum = "a29e6cbc2a24b8471b6567e580a0e8e7b70a6d0f0ea2be0844d1e842d7d4fa33"
 dependencies = [
  "async-io",
  "data-encoding",
  "dns-parser",
- "futures 0.3.16",
+ "futures 0.3.17",
  "if-watch",
  "lazy_static",
  "libp2p-core",
@@ -3804,17 +3772,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e9b544335d1ed30af71daa96edbefadef6f19c7a55f078b9fc92c87163105d"
+checksum = "313d9ea526c68df4425f580024e67a9d3ffd49f2c33de5154b1f5019816f7a99"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "bytes 1.0.1",
- "futures 0.3.16",
+ "bytes 1.1.0",
+ "futures 0.3.17",
  "libp2p-core",
  "log",
  "nohash-hasher",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "rand 0.7.3",
  "smallvec 1.6.1",
  "unsigned-varint 0.7.0",
@@ -3822,20 +3790,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36db0f0db3b0433f5b9463f1c0cd9eadc0a3734a9170439ce501ff99733a88bd"
+checksum = "3f1db7212f342b6ba7c981cc40e31f76e9e56cb48e65fa4c142ecaca5839523e"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "curve25519-dalek 3.2.0",
- "futures 0.3.16",
+ "futures 0.3.17",
  "lazy_static",
  "libp2p-core",
  "log",
  "prost",
  "prost-build",
- "rand 0.7.3",
- "sha2 0.9.5",
+ "rand 0.8.4",
+ "sha2 0.9.6",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -3844,11 +3812,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4bfaffac63bf3c7ec11ed9d8879d455966ddea7e78ee14737f0b6dce0d1cd1"
+checksum = "2482cfd9eb0b7a0baaf3e7b329dc4f2785181a161b1a47b7192f8d758f54a439"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3859,13 +3827,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8c37b4d2a075b4be8442760a5f8c037180f0c8dd5b5734b9978ab868b3aa11"
+checksum = "13b4783e5423870b9a5c199f65a7a3bc66d86ab56b2b9beebf3c338d889cf8e4"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "bytes 1.0.1",
- "futures 0.3.16",
+ "bytes 1.1.0",
+ "futures 0.3.17",
  "libp2p-core",
  "log",
  "prost",
@@ -3876,11 +3844,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-pnet"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce3374f3b28162db9d3442c9347c4f14cb01e8290052615c7d341d40eae0599"
+checksum = "07cb4dd4b917e5b40ddefe49b96b07adcd8d342e0317011d175b7b2bb1dcc974"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "log",
  "pin-project 1.0.8",
  "rand 0.7.3",
@@ -3890,13 +3858,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8786aca3f18671d8776289706a5521f6c9124a820f69e358de214b9939440d"
+checksum = "0133f6cfd81cdc16e716de2982e012c62e6b9d4f12e41967b3ee361051c622aa"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "bytes 1.0.1",
- "futures 0.3.16",
+ "bytes 1.1.0",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "libp2p-core",
  "libp2p-swarm",
@@ -3913,13 +3881,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdbe172f08e6d0f95fa8634e273d4c4268c4063de2e33e7435194b0130c62e3"
+checksum = "06cdae44b6821466123af93cbcdec7c9e6ba9534a8af9cdc296446d39416d241"
 dependencies = [
  "async-trait",
- "bytes 1.0.1",
- "futures 0.3.16",
+ "bytes 1.1.0",
+ "futures 0.3.17",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3933,12 +3901,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e04d8e1eef675029ec728ba14e8d0da7975d84b6679b699b4ae91a1de9c3a92"
+checksum = "7083861341e1555467863b4cd802bea1e8c4787c0f7b5110097d0f1f3248f9a9"
 dependencies = [
  "either",
- "futures 0.3.16",
+ "futures 0.3.17",
  "libp2p-core",
  "log",
  "rand 0.7.3",
@@ -3949,9 +3917,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365b0a699fea5168676840567582a012ea297b1ca02eee467e58301b9c9c5eed"
+checksum = "ab8cb308d4fc854869f5abb54fdab0833d2cf670d407c745849dc47e6e08d79c"
 dependencies = [
  "quote",
  "syn",
@@ -3959,12 +3927,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1a27d21c477951799e99d5c105d78868258502ce092988040a808d5a19bbd9"
+checksum = "79edd26b6b4bb5feee210dcda562dca186940dfecb0024b979c3f50824b3bf28"
 dependencies = [
  "async-io",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "if-watch",
  "ipnet",
@@ -3976,23 +3944,23 @@ dependencies = [
 
 [[package]]
 name = "libp2p-uds"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd6564bb3b7ff203661ccbb69003c2b551e34cef974f2d6c6a28306a12170b5"
+checksum = "280e793440dd4e9f273d714f4497325c72cddb0fe85a49f9a03c88f41dd20182"
 dependencies = [
  "async-std",
- "futures 0.3.16",
+ "futures 0.3.17",
  "libp2p-core",
  "log",
 ]
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d413e4cf9b8e5dfbcd2a60d3dc5a3391308bdb463684093d4f67137b7113de"
+checksum = "f553b7140fad3d7a76f50497b0ea591e26737d9607428a75509fc191e4d1b1f6"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "js-sys",
  "libp2p-core",
  "parity-send-wrapper",
@@ -4002,12 +3970,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cace60995ef6f637e4752cccbb2590f6bc358e8741a0d066307636c69a4b3a74"
+checksum = "ddf99dcbf5063e9d59087f61b1e85c686ceab2f5abedb472d32288065c0e5e27"
 dependencies = [
  "either",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-rustls",
  "libp2p-core",
  "log",
@@ -4020,13 +3988,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35da42cfc6d5cb0dcf3ad6881bc68d146cdf38f98655e09e33fbba4d13eabc4"
+checksum = "214cc0dd9c37cbed27f0bb1eba0c41bbafdb93a8be5e9d6ae1e6b4b42cd044bf"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "libp2p-core",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "thiserror",
  "yamux",
 ]
@@ -4045,17 +4013,20 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
+checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
 dependencies = [
  "arrayref",
- "crunchy",
- "digest 0.8.1",
+ "base64 0.12.3",
+ "digest 0.9.0",
  "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
  "rand 0.7.3",
- "sha2 0.8.2",
- "subtle 2.4.1",
+ "serde",
+ "sha2 0.9.6",
  "typenum",
 ]
 
@@ -4068,12 +4039,14 @@ dependencies = [
  "arrayref",
  "base64 0.12.3",
  "digest 0.9.0",
+ "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.6",
+ "typenum",
 ]
 
 [[package]]
@@ -4084,7 +4057,7 @@ checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
 dependencies = [
  "crunchy",
  "digest 0.9.0",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -4133,9 +4106,9 @@ dependencies = [
 
 [[package]]
 name = "linregress"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6e407dadb4ca4b31bc69c27aff00e7ca4534fdcee855159b039a7cebb5f395"
+checksum = "d6c601a85f5ecd1aba625247bca0031585fb1c446461b142878a16f8245ddeb8"
 dependencies = [
  "nalgebra",
  "statrs",
@@ -4152,9 +4125,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -4315,7 +4288,7 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "derive_more",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
 ]
 
@@ -4325,7 +4298,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c023c3f16109e7f33aa451f773fd61070e265b4977d0b6e344a51049296dd7df"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "rand 0.7.3",
  "thrift",
 ]
@@ -4442,6 +4415,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
+name = "multiaddr"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ee4ea82141951ac6379f964f71b20876d43712bea8faf6dd1a375e08a46499"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash 0.14.0",
+ "percent-encoding 2.1.0",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.7.0",
+ "url 2.2.2",
+]
+
+[[package]]
 name = "multibase"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4464,9 +4455,22 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.4",
  "multihash-derive",
- "sha2 0.9.5",
+ "sha2 0.9.6",
  "sha3",
  "unsigned-varint 0.5.1",
+]
+
+[[package]]
+name = "multihash"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "multihash-derive",
+ "sha2 0.9.6",
+ "unsigned-varint 0.7.0",
 ]
 
 [[package]]
@@ -4495,8 +4499,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d91ec0a2440aaff5f78ec35631a7027d50386c6163aa975f7caa0d5da4b6ff8"
 dependencies = [
- "bytes 1.0.1",
- "futures 0.3.16",
+ "bytes 1.1.0",
+ "futures 0.3.17",
  "log",
  "pin-project 1.0.8",
  "smallvec 1.6.1",
@@ -4661,9 +4665,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
  "memchr",
 ]
@@ -4674,7 +4678,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 dependencies = [
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -4716,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4732,7 +4736,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4747,7 +4751,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4761,7 +4765,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4784,7 +4788,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4805,7 +4809,7 @@ dependencies = [
  "frame-system",
  "pallet-session",
  "parity-scale-codec",
- "scale-info",
+ "scale-info 0.10.0",
  "serde",
  "sp-runtime",
  "sp-std",
@@ -4828,7 +4832,7 @@ dependencies = [
  "pallet-mmr-primitives",
  "pallet-session",
  "parity-scale-codec",
- "scale-info",
+ "scale-info 0.10.0",
  "serde",
  "sp-core",
  "sp-io",
@@ -4839,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4852,7 +4856,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4867,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "bitflags",
  "frame-support",
@@ -4890,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -4903,7 +4907,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4913,7 +4917,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4932,7 +4936,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -4944,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4959,7 +4963,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",
@@ -4978,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4994,7 +4998,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5016,7 +5020,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5031,7 +5035,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5049,7 +5053,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5064,7 +5068,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5079,7 +5083,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -5096,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5112,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5130,7 +5134,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5144,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5157,7 +5161,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5173,7 +5177,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5187,7 +5191,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5200,7 +5204,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5215,7 +5219,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5235,7 +5239,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",
@@ -5257,7 +5261,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -5268,7 +5272,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5281,7 +5285,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5299,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5313,7 +5317,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5329,7 +5333,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5346,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5357,7 +5361,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5372,7 +5376,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5386,7 +5390,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -5437,26 +5441,8 @@ dependencies = [
  "libc",
  "log",
  "memmap2",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "rand 0.8.4",
-]
-
-[[package]]
-name = "parity-multiaddr"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58341485071825827b7f03cf7efd1cb21e6a709bea778fb50227fd45d2f361b4"
-dependencies = [
- "arrayref",
- "bs58",
- "byteorder",
- "data-encoding",
- "multihash",
- "percent-encoding 2.1.0",
- "serde",
- "static_assertions",
- "unsigned-varint 0.7.0",
- "url 2.2.2",
 ]
 
 [[package]]
@@ -5522,7 +5508,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "lru",
  "parity-util-mem-derive",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "primitive-types",
  "smallvec 1.6.1",
  "winapi 0.3.9",
@@ -5601,13 +5587,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.4",
- "parking_lot_core 0.8.3",
+ "lock_api 0.4.5",
+ "parking_lot_core 0.8.5",
 ]
 
 [[package]]
@@ -5641,9 +5627,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -5661,21 +5647,20 @@ checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "pbkdf2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
-dependencies = [
- "byteorder",
- "crypto-mac 0.7.0",
-]
-
-[[package]]
-name = "pbkdf2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
 dependencies = [
  "crypto-mac 0.8.0",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
+dependencies = [
+ "crypto-mac 0.11.1",
 ]
 
 [[package]]
@@ -5830,7 +5815,7 @@ name = "polkadot-approval-distribution"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -5844,7 +5829,7 @@ name = "polkadot-availability-bitfield-distribution"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
@@ -5857,7 +5842,7 @@ name = "polkadot-availability-distribution"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "lru",
  "parity-scale-codec",
  "polkadot-erasure-coding",
@@ -5880,7 +5865,7 @@ name = "polkadot-availability-recovery"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "lru",
  "parity-scale-codec",
  "polkadot-erasure-coding",
@@ -5900,7 +5885,7 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "frame-benchmarking-cli",
- "futures 0.3.16",
+ "futures 0.3.17",
  "log",
  "polkadot-node-core-pvf",
  "polkadot-service",
@@ -5950,7 +5935,7 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "always-assert",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -5981,7 +5966,7 @@ name = "polkadot-dispute-distribution"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "lru",
  "parity-scale-codec",
  "polkadot-erasure-coding",
@@ -6019,7 +6004,7 @@ name = "polkadot-gossip-support"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
@@ -6038,9 +6023,9 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "async-trait",
- "futures 0.3.16",
+ "futures 0.3.17",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
@@ -6057,7 +6042,7 @@ name = "polkadot-node-collation-generation"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-primitives",
@@ -6077,7 +6062,7 @@ source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experime
 dependencies = [
  "bitvec 0.20.4",
  "derive_more",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "kvdb",
  "lru",
@@ -6106,7 +6091,7 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "bitvec 0.20.4",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "kvdb",
  "parity-scale-codec",
@@ -6126,7 +6111,7 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "bitvec 0.20.4",
- "futures 0.3.16",
+ "futures 0.3.17",
  "polkadot-erasure-coding",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -6143,7 +6128,7 @@ name = "polkadot-node-core-bitfield-signing"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
@@ -6159,7 +6144,7 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "async-trait",
- "futures 0.3.16",
+ "futures 0.3.17",
  "parity-scale-codec",
  "polkadot-node-core-pvf",
  "polkadot-node-primitives",
@@ -6176,7 +6161,7 @@ name = "polkadot-node-core-chain-api"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
@@ -6191,7 +6176,7 @@ name = "polkadot-node-core-chain-selection"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "kvdb",
  "parity-scale-codec",
@@ -6210,7 +6195,7 @@ source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experime
 dependencies = [
  "bitvec 0.20.4",
  "derive_more",
- "futures 0.3.16",
+ "futures 0.3.17",
  "kvdb",
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -6227,7 +6212,7 @@ name = "polkadot-node-core-dispute-participation"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-primitives",
@@ -6241,7 +6226,7 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "async-trait",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "polkadot-node-subsystem",
  "polkadot-primitives",
@@ -6258,7 +6243,7 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "bitvec 0.20.4",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
@@ -6276,7 +6261,7 @@ dependencies = [
  "assert_matches",
  "async-process",
  "async-std",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "libc",
  "parity-scale-codec",
@@ -6302,7 +6287,7 @@ name = "polkadot-node-core-runtime-api"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "memory-lru",
  "parity-util-mem",
  "polkadot-node-subsystem",
@@ -6325,7 +6310,7 @@ dependencies = [
  "log",
  "mick-jaeger",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "sc-network",
@@ -6339,7 +6324,7 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "async-trait",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "metered-channel",
  "sc-network",
@@ -6355,7 +6340,7 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "async-trait",
- "futures 0.3.16",
+ "futures 0.3.17",
  "parity-scale-codec",
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
@@ -6371,7 +6356,7 @@ name = "polkadot-node-primitives"
 version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "parity-scale-codec",
  "polkadot-parachain",
  "polkadot-primitives",
@@ -6408,13 +6393,13 @@ dependencies = [
  "async-std",
  "async-trait",
  "derive_more",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "lazy_static",
  "log",
  "mick-jaeger",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "pin-project 1.0.8",
  "polkadot-node-jaeger",
  "polkadot-node-network-protocol",
@@ -6436,9 +6421,9 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "async-trait",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
- "itertools 0.10.1",
+ "itertools",
  "lru",
  "metered-channel",
  "parity-scale-codec",
@@ -6466,10 +6451,10 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "async-trait",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "lru",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -6499,7 +6484,7 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "async-trait",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "metered-channel",
  "pin-project 1.0.8",
@@ -6758,7 +6743,7 @@ dependencies = [
  "beefy-gadget",
  "beefy-primitives",
  "frame-system-rpc-runtime-api",
- "futures 0.3.16",
+ "futures 0.3.17",
  "hex-literal",
  "kvdb",
  "kvdb-rocksdb",
@@ -6848,7 +6833,7 @@ version = "0.9.9-1"
 source = "git+https://github.com/paritytech/polkadot?branch=hc-contract-experiment-patched-v0.9.9#ba327c4ac0489e7273b1542c7366ac568645b193"
 dependencies = [
  "arrayvec 0.5.2",
- "futures 0.3.16",
+ "futures 0.3.17",
  "indexmap",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
@@ -6941,7 +6926,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-system",
  "futures 0.1.31",
- "futures 0.3.16",
+ "futures 0.3.17",
  "hex",
  "pallet-balances",
  "pallet-staking",
@@ -7000,21 +6985,23 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7456bc1ad2d4cf82b3a016be4c2ac48daf11bf990c1603ebd447fe6f30fca8"
+checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
- "cpuid-bool",
+ "cpufeatures",
+ "opaque-debug 0.3.0",
  "universal-hash",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.4.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
- "cpuid-bool",
+ "cfg-if 1.0.0",
+ "cpufeatures",
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
@@ -7121,9 +7108,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -7137,30 +7124,30 @@ dependencies = [
  "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "regex",
  "thiserror",
 ]
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "heck",
- "itertools 0.9.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
@@ -7172,12 +7159,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -7185,28 +7172,28 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "prost",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0617ee61163b5d941d804065ce49040967610a4d4278fae73e096a057b01d358"
+checksum = "cd136ff4382c4753fc061cb9e4712ab2af263376b95bbd5bd8cd50c020b78e69"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "pwasm-utils"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c1a2f10b47d446372a4f397c58b329aaea72b2daf9395a623a411cb8ccb54f"
+checksum = "880b3384fb00b8f6ecccd5d358b93bd2201900ae3daad213791d1864f6441f5c"
 dependencies = [
  "byteorder",
  "log",
@@ -7469,7 +7456,7 @@ checksum = "3bd8f48b2066e9f69ab192797d66da804d1935bf22763204ed3675740cb0f221"
 dependencies = [
  "derive_more",
  "fs-err",
- "itertools 0.10.1",
+ "itertools",
  "static_init",
  "thiserror",
 ]
@@ -7547,7 +7534,7 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "env_logger 0.8.4",
  "hex",
@@ -7608,7 +7595,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "rustc-hex",
 ]
 
@@ -7634,9 +7621,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hash"
@@ -7715,7 +7702,7 @@ dependencies = [
  "openssl-probe",
  "rustls 0.19.1",
  "schannel",
- "security-framework 2.3.1",
+ "security-framework 2.4.2",
 ]
 
 [[package]]
@@ -7734,7 +7721,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "pin-project 0.4.28",
  "static_assertions",
 ]
@@ -7756,9 +7743,9 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399f290ffc409596022fce5ea5d4138184be4784f2b28c62c59f0d8389059a15"
+checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
 dependencies = [
  "cipher",
 ]
@@ -7775,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "log",
  "sp-core",
@@ -7786,12 +7773,12 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "derive_more",
  "either",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "ip_network",
  "libp2p",
@@ -7815,9 +7802,9 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -7838,7 +7825,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7854,7 +7841,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7870,7 +7857,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -7881,11 +7868,11 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "chrono",
  "fdlimit",
- "futures 0.3.16",
+ "futures 0.3.17",
  "hex",
  "libp2p",
  "log",
@@ -7919,17 +7906,17 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "derive_more",
  "fnv",
- "futures 0.3.16",
+ "futures 0.3.17",
  "hash-db",
  "kvdb",
  "lazy_static",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "sc-executor",
  "sc-transaction-pool-api",
  "sp-api",
@@ -7953,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -7965,7 +7952,7 @@ dependencies = [
  "parity-db",
  "parity-scale-codec",
  "parity-util-mem",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "sc-client-api",
  "sc-executor",
  "sc-state-db",
@@ -7982,14 +7969,14 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "sc-client-api",
  "serde",
  "sp-api",
@@ -8007,11 +7994,11 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -8039,12 +8026,12 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "derive_more",
  "fork-tree",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "log",
  "merlin",
@@ -8052,7 +8039,7 @@ dependencies = [
  "num-rational 0.2.4",
  "num-traits",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "pdqselect",
  "rand 0.7.3",
  "retain_mut",
@@ -8086,10 +8073,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "derive_more",
- "futures 0.3.16",
+ "futures 0.3.17",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -8110,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -8123,10 +8110,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "impl-trait-for-tuples",
  "log",
@@ -8152,7 +8139,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "sc-client-api",
  "sp-authorship",
@@ -8163,15 +8150,15 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "derive_more",
  "lazy_static",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.6.0",
  "log",
  "parity-scale-codec",
  "parity-wasm 0.42.2",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "sc-executor-common",
  "sc-executor-wasmi",
  "sc-executor-wasmtime",
@@ -8192,7 +8179,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -8209,7 +8196,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8224,7 +8211,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -8244,19 +8231,19 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "derive_more",
  "dyn-clone",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "pin-project 1.0.8",
  "rand 0.8.4",
  "sc-block-builder",
@@ -8285,11 +8272,11 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "derive_more",
  "finality-grandpa",
- "futures 0.3.16",
+ "futures 0.3.17",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -8309,10 +8296,10 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "ansi_term 0.12.1",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "log",
  "parity-util-mem",
@@ -8327,32 +8314,32 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-util",
  "hex",
  "merlin",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "rand 0.7.3",
  "serde_json",
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
 name = "sc-light"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "hash-db",
  "lazy_static",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "sc-client-api",
  "sc-executor",
  "sp-api",
@@ -8366,21 +8353,21 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-std",
  "async-trait",
  "asynchronous-codec 0.5.0",
  "bitflags",
  "bs58",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "cid",
  "derive_more",
  "either",
  "erased-serde",
  "fnv",
  "fork-tree",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "hex",
  "ip_network",
@@ -8391,7 +8378,7 @@ dependencies = [
  "lru",
  "nohash-hasher",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "pin-project 1.0.8",
  "prost",
  "prost-build",
@@ -8421,9 +8408,9 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -8438,11 +8425,11 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "hex",
  "hyper 0.13.10",
@@ -8450,7 +8437,7 @@ dependencies = [
  "log",
  "num_cpus",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "rand 0.7.3",
  "sc-client-api",
  "sc-keystore",
@@ -8466,9 +8453,9 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "libp2p",
  "log",
  "serde_json",
@@ -8479,7 +8466,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8488,15 +8475,15 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -8523,17 +8510,17 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "derive_more",
- "futures 0.3.16",
+ "futures 0.3.17",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "jsonrpc-pubsub",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "sc-chain-spec",
  "sc-transaction-pool-api",
  "serde",
@@ -8548,7 +8535,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "futures 0.1.31",
  "jsonrpc-core",
@@ -8566,13 +8553,13 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "directories",
  "exit-future",
  "futures 0.1.31",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "hash-db",
  "jsonrpc-core",
@@ -8581,7 +8568,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parity-util-mem",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "pin-project 1.0.8",
  "rand 0.7.3",
  "sc-block-builder",
@@ -8634,13 +8621,13 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "log",
  "parity-scale-codec",
  "parity-util-mem",
  "parity-util-mem-derive",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "sc-client-api",
  "sp-core",
  "thiserror",
@@ -8649,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -8671,13 +8658,13 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "chrono",
- "futures 0.3.16",
+ "futures 0.3.17",
  "libp2p",
  "log",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "pin-project 1.0.8",
  "rand 0.7.3",
  "serde",
@@ -8691,7 +8678,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -8699,7 +8686,7 @@ dependencies = [
  "lazy_static",
  "log",
  "once_cell",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "regex",
  "rustc-hash",
  "sc-client-api",
@@ -8728,7 +8715,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -8739,16 +8726,16 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "derive_more",
- "futures 0.3.16",
+ "futures 0.3.17",
  "intervalier",
  "linked-hash-map",
  "log",
  "parity-scale-codec",
  "parity-util-mem",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "retain_mut",
  "sc-client-api",
  "sc-transaction-pool-api",
@@ -8768,10 +8755,10 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "derive_more",
- "futures 0.3.16",
+ "futures 0.3.17",
  "log",
  "parity-scale-codec",
  "serde",
@@ -8790,7 +8777,20 @@ dependencies = [
  "cfg-if 1.0.0",
  "derive_more",
  "parity-scale-codec",
- "scale-info-derive",
+ "scale-info-derive 0.7.0",
+]
+
+[[package]]
+name = "scale-info"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55b744399c25532d63a0d2789b109df8d46fc93752d46b0782991a931a782f"
+dependencies = [
+ "bitvec 0.20.4",
+ "cfg-if 1.0.0",
+ "derive_more",
+ "parity-scale-codec",
+ "scale-info-derive 1.0.0",
 ]
 
 [[package]]
@@ -8798,6 +8798,18 @@ name = "scale-info-derive"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b648fa291891a4c80187a25532f6a7d96b82c70353e30b868b14632b8fe043d6"
+dependencies = [
+ "proc-macro-crate 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -8829,7 +8841,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "sha2 0.8.2",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -8879,15 +8891,15 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.3.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
 dependencies = [
  "bitflags",
  "core-foundation 0.9.1",
  "core-foundation-sys 0.8.2",
  "libc",
- "security-framework-sys 2.3.0",
+ "security-framework-sys 2.4.2",
 ]
 
 [[package]]
@@ -8902,9 +8914,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.3.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
 dependencies = [
  "core-foundation-sys 0.8.2",
  "libc",
@@ -8955,18 +8967,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.127"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8975,9 +8987,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
  "itoa",
  "ryu",
@@ -8998,9 +9010,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0c8611594e2ab4ebbf06ec7cbbf0a99450b8570e96cbf5188b5d5f6ef18d81"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -9023,9 +9035,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -9057,15 +9069,15 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
+checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -9127,9 +9139,9 @@ dependencies = [
 
 [[package]]
 name = "slotmap"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a952280edbecfb1d4bd3cf2dbc309dc6ab523e53487c438ae21a6df09fe84bc4"
+checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
 dependencies = [
  "version_check",
 ]
@@ -9151,19 +9163,19 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "snow"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795dd7aeeee24468e5a32661f6d27f7b5cbed802031b2d7640c7b10f8fb2dd50"
+checksum = "6142f7c25e94f6fd25a32c3348ec230df9109b463f59c8c7acc4bd34936babb7"
 dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.4",
+ "rand_core 0.6.3",
  "ring",
- "rustc_version 0.2.3",
- "sha2 0.9.5",
- "subtle 2.4.1",
+ "rustc_version 0.3.3",
+ "sha2 0.9.6",
+ "subtle",
  "x25519-dalek",
 ]
 
@@ -9197,11 +9209,11 @@ dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
  "flate2",
- "futures 0.3.16",
+ "futures 0.3.17",
  "httparse",
  "log",
  "rand 0.7.3",
- "sha-1 0.9.7",
+ "sha-1 0.9.8",
 ]
 
 [[package]]
@@ -9211,18 +9223,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74e48087dbeed4833785c2f3352b59140095dc192dce966a3bfc155020a439f"
 dependencies = [
  "base64 0.13.0",
- "bytes 1.0.1",
- "futures 0.3.16",
+ "bytes 1.1.0",
+ "futures 0.3.17",
  "httparse",
  "log",
  "rand 0.8.4",
- "sha-1 0.9.7",
+ "sha-1 0.9.8",
 ]
 
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "hash-db",
  "log",
@@ -9239,7 +9251,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.0.0",
@@ -9251,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9263,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -9277,7 +9289,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9289,7 +9301,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9301,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9313,13 +9325,13 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "log",
  "lru",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "sp-api",
  "sp-consensus",
  "sp-database",
@@ -9331,14 +9343,14 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "serde",
  "sp-api",
  "sp-core",
@@ -9357,7 +9369,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9374,7 +9386,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "merlin",
@@ -9396,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -9406,7 +9418,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -9418,33 +9430,33 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "base58",
  "blake2-rfc",
  "byteorder",
  "dyn-clonable",
  "ed25519-dalek",
- "futures 0.3.16",
+ "futures 0.3.17",
  "hash-db",
  "hash256-std-hasher",
  "hex",
  "impl-serde",
  "lazy_static",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.6.0",
  "log",
  "merlin",
  "num-traits",
  "parity-scale-codec",
  "parity-util-mem",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "primitive-types",
  "rand 0.7.3",
  "regex",
  "schnorrkel",
  "secrecy",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.6",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -9462,16 +9474,16 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "kvdb",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9481,7 +9493,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9492,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9509,7 +9521,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9523,14 +9535,14 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "hash-db",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.6.0",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
@@ -9548,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -9559,14 +9571,14 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.16",
+ "futures 0.3.17",
  "merlin",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "schnorrkel",
  "serde",
  "sp-core",
@@ -9576,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "ruzstd",
  "zstd",
@@ -9585,7 +9597,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9598,7 +9610,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -9609,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9619,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "backtrace",
 ]
@@ -9627,7 +9639,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9638,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9659,7 +9671,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9676,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.0.0",
@@ -9688,7 +9700,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9702,7 +9714,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "serde",
  "serde_json",
@@ -9711,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9724,7 +9736,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -9734,13 +9746,13 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "hash-db",
  "log",
  "num-traits",
  "parity-scale-codec",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "rand 0.7.3",
  "smallvec 1.6.1",
  "sp-core",
@@ -9757,12 +9769,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9775,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "log",
  "sp-core",
@@ -9788,7 +9800,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -9805,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "erased-serde",
  "log",
@@ -9823,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -9832,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "log",
@@ -9847,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -9861,9 +9873,9 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-core",
  "futures-timer 3.0.2",
  "lazy_static",
@@ -9873,7 +9885,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9888,7 +9900,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate 1.0.0",
@@ -9900,7 +9912,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9934,7 +9946,7 @@ checksum = "11b73400442027c4adedda20a9f9b7945234a5bd8d5f7e86da22bd5d0622369c"
 dependencies = [
  "cfg_aliases",
  "libc",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "static_init_macro",
 ]
 
@@ -9965,16 +9977,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stream-cipher"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
-dependencies = [
- "block-cipher",
- "generic-array 0.14.4",
-]
-
-[[package]]
 name = "string"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9991,9 +9993,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
+checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
 dependencies = [
  "clap",
  "lazy_static",
@@ -10002,9 +10004,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
+checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
 dependencies = [
  "heck",
  "proc-macro-error 1.0.4",
@@ -10036,21 +10038,21 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed6646a0159b9935b5d045611560eeef842b78d7adc3ba36f5ca325a13a0236"
+checksum = "49eee6965196b32f882dd2ee85a92b1dbead41b04e53907f269de3b0dc04733c"
 dependencies = [
- "hmac 0.7.1",
- "pbkdf2 0.3.0",
+ "hmac 0.11.0",
+ "pbkdf2 0.8.0",
  "schnorrkel",
- "sha2 0.8.2",
+ "sha2 0.9.6",
  "zeroize",
 ]
 
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "platforms",
 ]
@@ -10058,10 +10060,10 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-system-rpc-runtime-api",
- "futures 0.3.16",
+ "futures 0.3.17",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -10081,7 +10083,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-std",
  "derive_more",
@@ -10095,11 +10097,11 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "async-trait",
  "futures 0.1.31",
- "futures 0.3.16",
+ "futures 0.3.17",
  "hash-db",
  "hex",
  "parity-scale-codec",
@@ -10124,7 +10126,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -10139,21 +10141,15 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-
-[[package]]
-name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10235,18 +10231,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10307,7 +10303,7 @@ dependencies = [
  "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",
- "sha2 0.9.5",
+ "sha2 0.9.6",
  "thiserror",
  "unicode-normalization",
  "zeroize",
@@ -10386,9 +10382,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
+checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
 dependencies = [
  "autocfg",
  "pin-project-lite 0.2.7",
@@ -10794,7 +10790,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "resolv-conf",
  "smallvec 1.6.1",
  "thiserror",
@@ -10810,7 +10806,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#6080e7a33e63558bf619c240b1ada2cb08c8b443"
+source = "git+https://github.com/paritytech/substrate?branch=hc-contract-experiment-patched-v0.9.9#b409c7099407e7cdc0fcdb89e8e2fdf7f8256ccb"
 dependencies = [
  "frame-try-runtime",
  "log",
@@ -10845,9 +10841,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "ucd-trie"
@@ -10916,7 +10912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -10932,7 +10928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
  "asynchronous-codec 0.5.0",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-io",
  "futures-util",
 ]
@@ -10944,7 +10940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f8d425fafb8cd76bc3f22aace4af471d3156301d7508f2107e98fbeae10bc7f"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-io",
  "futures-util",
 ]
@@ -11064,9 +11060,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.75"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+checksum = "5e68338db6becec24d3c7977b5bf8a48be992c934b5d07177e3931f5dc9b076c"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -11074,9 +11070,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.75"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+checksum = "f34c405b4f0658583dba0c1c7c9b694f3cac32655db463b56c254a1c75269523"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -11089,9 +11085,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
+checksum = "a87d738d4abc4cf22f6eb142f5b9a81301331ee3c767f2fef2fda4e325492060"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -11101,9 +11097,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.75"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+checksum = "b9d5a6580be83b19dc570a8f9c324251687ab2184e57086f71625feb57ec77c8"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -11111,9 +11107,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.75"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+checksum = "e3775a030dc6f5a0afd8a84981a21cc92a781eb429acef9ecce476d0c9113e92"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11124,9 +11120,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.75"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+checksum = "c279e376c7a8e8752a8f1eaa35b7b0bee6bb9fb0cdacfa97cc3f1f289c87e2b4"
 
 [[package]]
 name = "wasm-gc-api"
@@ -11145,9 +11141,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "js-sys",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -11231,7 +11227,7 @@ dependencies = [
  "libc",
  "log",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.6",
  "toml",
  "winapi 0.3.9",
  "zstd",
@@ -11376,9 +11372,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.52"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
+checksum = "0a84d70d1ec7d2da2d26a5bd78f4bca1b8c3254805363ce743b7a05bc30d195a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11561,19 +11557,19 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
 dependencies = [
- "futures 0.3.16",
+ "futures 0.3.17",
  "log",
  "nohash-hasher",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "rand 0.8.4",
  "static_assertions",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]


### PR DESCRIPTION
This is needed so that `canvas-node` can be built with the latest Rust nightly. Currently our CI fails for ink! and `ink-waterfall`, since it tries to use `canvas-node` with latest Rust nightly. 