### PR TITLE
Rename `canvas-node` repo to `canvas`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# canvas-node
+# Canvas
 
 This is a node implementation for Canvas, a [Substrate](https://github.com/paritytech/substrate)
 parachain for smart contracts.
 
-It uses Substrate's smart contract module ‒ the
-[`contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
+It is based on the
+[`substrate-parachain-template`](https://github.com/substrate-developer-hub/substrate-parachain-template/),
+which we modified to use Substrate's smart contract module ‒ the [`contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
 pallet.
 
 **Note:** This used to be a standalone smart contract node used for the ink! workshop. We
@@ -14,16 +15,16 @@ have moved the standalone node to [substrate-contracts-node](https://github.com/
 
 ### Installation 
 
-You need to have executables of both Polkadot, as well as `canvas-node`.
+You need to have executables of both Polkadot, as well as Canvas.
 
 Binary releases can be found here:
 [Polkadot releases](https://github.com/paritytech/polkadot/releases),
-[Canvas releases](https://github.com/paritytech/canvas-node/releases).
+[Canvas releases](https://github.com/paritytech/canvas/releases).
 
 Alternatively you can install (or build) the projects yourself:
 
-* `cargo install polkadot-node --git https://github.com/paritytech/polkadot.git --force --locked`
-* `cargo install canvas-node --git https://github.com/paritytech/canvas-node.git --force --locked`
+* `cargo install --git https://github.com/paritytech/polkadot.git --force --locked`
+* `cargo install --git https://github.com/paritytech/canvas.git --force --locked`
 
 The `--locked` flag makes the installation (or build) use the same versions as the `Cargo.lock`
 in those repositories ‒ ensuring that the last known-to-work version of the dependencies is used.
@@ -54,8 +55,8 @@ to set up all Substrate prerequisites.
 Afterwards you can install this node via
 
 ```bash
-git clone https://github.com/paritytech/canvas-node.git 
-cd canvas-node/
+git clone https://github.com/paritytech/canvas.git 
+cd canvas/
 cargo build --release --locked 
 ```
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,9 +3,9 @@ name = "canvas-node"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "GPL-3.0-only"
-description = "A node implementation for Canvas, a Substrate chain for smart contracts."
-homepage = "https://github.com/paritytech/canvas-node"
-repository = "https://github.com/paritytech/canvas-node"
+description = "A node implementation for Canvas, a Substrate parachain for smart contracts."
+homepage = "https://github.com/paritytech/canvas"
+repository = "https://github.com/paritytech/canvas"
 build = "build.rs"
 edition = "2018"
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -70,7 +70,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn support_url() -> String {
-		"https://github.com/paritytech/canvas-node/issues/new".into()
+		"https://github.com/paritytech/canvas/issues/new".into()
 	}
 
 	fn copyright_start_year() -> i32 {
@@ -108,7 +108,7 @@ impl SubstrateCli for RelayChainCli {
 	}
 
 	fn support_url() -> String {
-		"https://github.com/paritytech/canvas-node/issues/new".into()
+		"https://github.com/paritytech/canvas/issues/new".into()
 	}
 
 	fn copyright_start_year() -> i32 {


### PR DESCRIPTION
After this PR is merged I'll rename the repo.

I'll subsequently create follow-ups for:
* The CI team, so that they adapt GitLab.
* All other repositories which somehow use `canvas-node` (`ink-waterfall`, etc.).
* The Dockerfiles which reference this repo.

There will necessarily be a (hopefully short) timeframe when the CI for this project and once which depend on it won't work.

If everything works again I'll announce in our public channels that we've renamed the repo.